### PR TITLE
Tweak exit instructions formatting

### DIFF
--- a/AMDirT/filter/run_streamlit.py
+++ b/AMDirT/filter/run_streamlit.py
@@ -4,7 +4,6 @@ from streamlit import cli as stcli
 from pathlib import Path
 from AMDirT.filter.utils import get_json_path
 
-
 def run_app(tables=None):
     directory = Path(__file__).parent.resolve()
     app = "streamlit.py"
@@ -15,5 +14,5 @@ def run_app(tables=None):
     app_path = f"{directory}/{app}"
 
     sys.argv = ["streamlit", "run", app_path, "--", "--config", config_path]
-    logging.info("To close app, press on your keyboard: Ctrl+C")
+    logging.info("\n[AMDirT] To close app, press on your keyboard: ctrl+c\n")
     sys.exit(stcli.main())


### PR DESCRIPTION
Tweaks slightly the output formatting to make it clearer.

Currently it's sort of hidden

![image](https://user-images.githubusercontent.com/17950287/149311014-23608960-9a5e-4096-9bcf-5b7c52cbfaeb.png)

The new version adds new lines and changes formt to make it stand out more

![image](https://user-images.githubusercontent.com/17950287/149311063-c1c8751e-f210-48cc-9b46-2514370dff2a.png)


Note, I don't know where this `root:` thing is coming from. Might be nice to remove that if possible, but fine if not.