### PR TITLE
added reading the filtered "samples" table, and accounted for empty "output" argument in run_convert function

### DIFF
--- a/AMDirT/convert/main.py
+++ b/AMDirT/convert/main.py
@@ -20,8 +20,8 @@ def run_convert(samples, table_name, tables, output):
     if table_name not in table_list:
         logging.info(f"Table '{table_name}' not found in {table_list}")
 
-    #fixme
     libraries = pd.read_csv(tables["libraries"][table_name], sep="\t")
+    samples = pd.read_csv(samples, sep="\t")
 
     eager_table = prepare_eager_table(
         samples=samples,
@@ -37,7 +37,9 @@ def run_convert(samples, table_name, tables, output):
         supported_archives=supported_archives,
     )
 
-    eager_table.to_csv(f"{output}/eager_input_table.tsv", sep="\t", index=False)
-    accession_table.to_csv(
-        f"{output}/fetchNGS_input_table.tsv", sep="\t", header=False, index=False
-    )
+    if output is None:
+        eager_table.to_csv(f"eager_input_table.tsv", sep="\t", index=False)
+        accession_table.to_csv(f"fetchNGS_input_table.tsv", sep="\t", header=False, index=False)
+    else:
+        eager_table.to_csv(f"{output}/eager_input_table.tsv", sep="\t", index=False)
+        accession_table.to_csv(f"{output}/fetchNGS_input_table.tsv", sep="\t", header=False, index=False)

--- a/AMDirT/convert/main.py
+++ b/AMDirT/convert/main.py
@@ -20,7 +20,7 @@ def run_convert(samples, table_name, tables, output):
     if table_name not in table_list:
         logging.info(f"Table '{table_name}' not found in {table_list}")
 
-    #libraries = pd.read_csv(table_list["libraries"][table_name], sep="\t")
+    #fixme
     libraries = pd.read_csv(tables["libraries"][table_name], sep="\t")
 
     eager_table = prepare_eager_table(

--- a/AMDirT/convert/main.py
+++ b/AMDirT/convert/main.py
@@ -20,7 +20,8 @@ def run_convert(samples, table_name, tables, output):
     if table_name not in table_list:
         logging.info(f"Table '{table_name}' not found in {table_list}")
 
-    libraries = pd.read_csv(table_list["libraries"][table_name], sep="\t")
+    #libraries = pd.read_csv(table_list["libraries"][table_name], sep="\t")
+    libraries = pd.read_csv(tables["libraries"][table_name], sep="\t")
 
     eager_table = prepare_eager_table(
         samples=samples,


### PR DESCRIPTION
I encountered this error:

```
(AMDirT) nikolay@dell:~/WABI/Misc/SPAAM/AMDirT$ AMDirT convert test/valid.tsv ancientmetagenome-hostassociated
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/AMDirT", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.6/dist-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.6/dist-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.6/dist-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.6/dist-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/AMDirT/cli.py", line 93, in convert
    run_convert(**kwargs)
  File "/usr/local/lib/python3.6/dist-packages/AMDirT/convert/main.py", line 31, in run_convert
    supported_archives=supported_archives,
  File "/usr/local/lib/python3.6/dist-packages/streamlit/legacy_caching/caching.py", line 573, in wrapped_func
    return get_or_create_cached_value()
  File "/usr/local/lib/python3.6/dist-packages/streamlit/legacy_caching/caching.py", line 557, in get_or_create_cached_value
    return_value = func(*args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/AMDirT/core/utils.py", line 90, in prepare_eager_table
    samples.query("archive in @supported_archives")
AttributeError: 'str' object has no attribute 'query'
```

The error seems to be coming from the fact that "samples" and "output" arguments of run_convert are None. The error can be fixed by explicit reading the filtered samples table and adding a conditional on possible None output. For now, if "output" is None, the output files will be written in the directory where AMDirT is run from. Fixing those lines made my "AMDirT convert" run without errors and output what I wanted, i.e. the tables for eager and fetchNGS