### PR TITLE
Fix URLs after latest release

### DIFF
--- a/AMDirT/assets/tables.json
+++ b/AMDirT/assets/tables.json
@@ -1,12 +1,12 @@
 {
   "samples": {
-    "ancientmetagenome-environmental": "https://raw.githubusercontent.com/SPAAM-community/AncientMetagenomeDir/dev/ancientmetagenome-environmental/samples/ancientmetagenome-environmental_samples.tsv",
-    "ancientmetagenome-hostassociated": "https://raw.githubusercontent.com/SPAAM-community/AncientMetagenomeDir/dev/ancientmetagenome-hostassociated/samples/ancientmetagenome-hostassociated_samples.tsv",
-    "ancientsinglegenome-hostassociated": "https://raw.githubusercontent.com/SPAAM-community/AncientMetagenomeDir/dev/ancientsinglegenome-hostassociated/samples/ancientsinglegenome-hostassociated_samples.tsv"
+    "ancientmetagenome-environmental": "https://raw.githubusercontent.com/SPAAM-community/AncientMetagenomeDir/master/ancientmetagenome-environmental/samples/ancientmetagenome-environmental_samples.tsv",
+    "ancientmetagenome-hostassociated": "https://raw.githubusercontent.com/SPAAM-community/AncientMetagenomeDir/master/ancientmetagenome-hostassociated/samples/ancientmetagenome-hostassociated_samples.tsv",
+    "ancientsinglegenome-hostassociated": "https://raw.githubusercontent.com/SPAAM-community/AncientMetagenomeDir/master/ancientsinglegenome-hostassociated/samples/ancientsinglegenome-hostassociated_samples.tsv"
   },
   "libraries": {
-    "ancientmetagenome-environmental": "https://raw.githubusercontent.com/SPAAM-community/AncientMetagenomeDir/dev/ancientmetagenome-environmental/libraries/ancientmetagenome-environmental_libraries.tsv",
-    "ancientmetagenome-hostassociated": "https://raw.githubusercontent.com/SPAAM-community/AncientMetagenomeDir/dev/ancientmetagenome-hostassociated/libraries/ancientmetagenome-hostassociated_libraries.tsv",
-    "ancientsinglegenome-hostassociated": "https://raw.githubusercontent.com/SPAAM-community/AncientMetagenomeDir/dev/ancientsinglegenome-hostassociated/libraries/ancientsinglegenome-hostassociated_libraries.tsv"
+    "ancientmetagenome-environmental": "https://raw.githubusercontent.com/SPAAM-community/AncientMetagenomeDir/master/ancientmetagenome-environmental/libraries/ancientmetagenome-environmental_libraries.tsv",
+    "ancientmetagenome-hostassociated": "https://raw.githubusercontent.com/SPAAM-community/AncientMetagenomeDir/master/ancientmetagenome-hostassociated/libraries/ancientmetagenome-hostassociated_libraries.tsv",
+    "ancientsinglegenome-hostassociated": "https://raw.githubusercontent.com/SPAAM-community/AncientMetagenomeDir/master/ancientsinglegenome-hostassociated/libraries/ancientsinglegenome-hostassociated_libraries.tsv"
   }
 }

--- a/AMDirT/filter/streamlit.py
+++ b/AMDirT/filter/streamlit.py
@@ -16,7 +16,7 @@ from AMDirT.core.utils import (
 
 st.set_page_config(
     page_title="AMDirT Filter",
-    page_icon="https://raw.githubusercontent.com/SPAAM-community/AncientMetagenomeDir/dev/assets/images/spaam-AncientMetagenomeDir_logo_mini.png",
+    page_icon="https://raw.githubusercontent.com/SPAAM-community/AncientMetagenomeDir/master/assets/images/logos/spaam-AncientMetagenomeDir_logo_mini.png",
     layout="wide",
 )
 
@@ -52,7 +52,7 @@ with open(args.config) as c:
 with st.sidebar:
     st.markdown(
         """
-<p style="text-align:center;"><img src="https://raw.githubusercontent.com/SPAAM-community/AncientMetagenomeDir/master/assets/images/spaam-AncientMetagenomeDir_logo_colourmode.svg" alt="logo" width="50%"></p>
+<p style="text-align:center;"><img src="https://raw.githubusercontent.com/SPAAM-community/AncientMetagenomeDir/master/assets/images/logos/spaam-AncientMetagenomeDir_logo_colourmode.svg" alt="logo" width="50%"></p>
 """,
         unsafe_allow_html=True,
     )


### PR DESCRIPTION
Points back to master, and updates paths to the logos (which should be in a fixed structure now)