### PR TITLE
Add warning about DOIs that do not return a BibTex string

### DIFF
--- a/AMDirT/core/__init__.py
+++ b/AMDirT/core/__init__.py
@@ -242,17 +242,29 @@ def prepare_accession_table(
     }
 
 
-@st.cache()
+@st.cache(suppress_st_warning=True)
 def prepare_bibtex_file(samples: pd.DataFrame) -> str:
     dois = set()
+    failed_dois = set()
     dois_set = set(list(samples["publication_doi"]))
     dois_set.add("10.1038/s41597-021-00816-y")
     for doi in dois_set:
         try:
-            dois.add(doi2bib(doi))
+            bibtex_str = doi2bib(doi)
+            if len(bibtex_str) == 0:
+                failed_dois.add(doi)
+            else:
+                dois.add(bibtex_str)
         except Exception as e:
             logger.info(e)
             pass
+    # Print warning for DOIs that do not have an entry
+    st.warning("Citation information could not be resolved for the following "
+               "DOIs: " + ", ".join(failed_dois) + ". Please check how to cite "
+               "these publications manually!")
+    logger.warning("Citation information could not be resolved for the "
+                   "following DOIs: " + ", ".join(failed_dois) + ". Please "
+                   "check how to cite these publications manually!")
 
     dois_string = "\n".join(list(dois))
     return dois_string

--- a/AMDirT/core/__init__.py
+++ b/AMDirT/core/__init__.py
@@ -259,12 +259,13 @@ def prepare_bibtex_file(samples: pd.DataFrame) -> str:
             logger.info(e)
             pass
     # Print warning for DOIs that do not have an entry
-    st.warning("Citation information could not be resolved for the following "
-               "DOIs: " + ", ".join(failed_dois) + ". Please check how to cite "
-               "these publications manually!")
-    logger.warning("Citation information could not be resolved for the "
+    if len(failed_dois) > 0:
+        st.warning("Citation information could not be resolved for the "
                    "following DOIs: " + ", ".join(failed_dois) + ". Please "
                    "check how to cite these publications manually!")
+        logger.warning("Citation information could not be resolved for the "
+                       "following DOIs: " + ", ".join(failed_dois) + ". Please "
+                       "check how to cite these publications manually!")
 
     dois_string = "\n".join(list(dois))
     return dois_string


### PR DESCRIPTION
Adds a warning message to the Streamlit app and the terminal whenever a study does not have a valid BibTex entry at doi.org and returns an empty string.

Would close issue #67 .