### PR TITLE
Viewer tweaks

### DIFF
--- a/AMDirT/viewer/streamlit.py
+++ b/AMDirT/viewer/streamlit.py
@@ -161,8 +161,6 @@ if st.session_state.table_name != "No table selected":
 
         with placeholder.container():
             
-            st.warning("By default all download scripts/inputs include ALL libraries of the selected samples. We highly recommend reviewing the AncientMetagenomeDir library table prior using any other table, to ensure you only download/use relevant libraries!")
-
             (
                 button_libraries,
                 button_fastq, 
@@ -349,6 +347,9 @@ if st.session_state.table_name != "No table selected":
                         file_name="ancientMetagenomeDir_citations.bib",
                     )
                 
+                st.markdown("ℹ️ _By default all download scripts/inputs include ALL libraries of the selected samples. \n Review the AncientMetagenomeDir library table prior using any other table, to ensure usage of relevant libraries!_")
+                st.markdown("⚠️ _We provide no warranty to the accuracy of the generated input sheets._")
+
                 if st.button("Start New Selection", type="primary"):
                     st.session_state.compute = False
                     st.session_state.table_name = "No table selected"

--- a/AMDirT/viewer/streamlit.py
+++ b/AMDirT/viewer/streamlit.py
@@ -160,14 +160,17 @@ if st.session_state.table_name != "No table selected":
         placeholder = st.empty()
 
         with placeholder.container():
+            
+            st.warning("By default all download scripts/inputs include ALL libraries of the selected samples. We highly recommend reviewing the AncientMetagenomeDir library table prior using any other table, to ensure you only download/use relevant libraries!")
+
             (
+                button_libraries,
                 button_fastq, 
                 button_samplesheet_eager, 
                 button_samplesheet_mag,
                 button_samplesheet_taxprofiler, 
                 button_samplesheet_ameta,
-                button_bibtex,
-                button_libraries
+                button_bibtex
             ) = st.columns(7)
             
             if st.session_state.force_validation:
@@ -188,6 +191,24 @@ if st.session_state.table_name != "No table selected":
                     total_size_str = f"{total_size / 1e12:.2f}TB"
                 else:
                     total_size_str = f"{total_size / 1e9:.2f}GB"
+
+                ###################
+                ## LIBRARY TABLE ##
+                ###################
+
+                with button_libraries:
+                    st.download_button(
+                        label="Download AncientMetagenomeDir Library Table",
+                        data=get_libraries(
+                            table_name=st.session_state.table_name,
+                            libraries=library,
+                            samples=pd.DataFrame(df_mod["selected_rows"]),
+                            supported_archives=supported_archives,
+                        )
+                        .to_csv(sep="\t", index=False)
+                        .encode("utf-8"),
+                        file_name="ancientMetagenomeDir_library_table.csv",
+                    )
 
                 ############################
                 ## FASTQ DOWNLOAD SCRIPTS ##
@@ -326,24 +347,6 @@ if st.session_state.table_name != "No table selected":
                         label="Download Citations as BibTex",
                         data=prepare_bibtex_file(pd.DataFrame(df_mod["selected_rows"])),
                         file_name="ancientMetagenomeDir_citations.bib",
-                    )
-
-                ###################
-                ## LIBRARY TABLE ##
-                ###################
-
-                with button_libraries:
-                    st.download_button(
-                        label="Download Library Table",
-                        data=get_libraries(
-                            table_name=st.session_state.table_name,
-                            libraries=library,
-                            samples=pd.DataFrame(df_mod["selected_rows"]),
-                            supported_archives=supported_archives,
-                        )
-                        .to_csv(sep="\t", index=False)
-                        .encode("utf-8"),
-                        file_name="ancientMetagenomeDir_library_table.csv",
                     )
                 
                 if st.button("Start New Selection", type="primary"):


### PR DESCRIPTION
I've moved the AncientMetagenomeDir library button first, and renamed as such. It's always critical a user reviews this (to allow filtering of the subsequent input sheets/download files), so they don't download e.g. non-UDG data when the only want UDG treated data. Therefore this should be more prominent

I've also added some additional text warnings along those lines, also that we don't assume the generated sheets are correct.