### PR TITLE
Add ena table output amdirt autofill

### DIFF
--- a/amdirt/autofill/__init__.py
+++ b/amdirt/autofill/__init__.py
@@ -7,7 +7,7 @@ import json
 import sys
 import pandas as pd
 
-def run_autofill(accession, table_name=None, schema=None, dataset=None, sample_output=None, library_output=None, verbose=False, output_ena_table=False):
+def run_autofill(accession, table_name=None, schema=None, dataset=None, sample_output=None, library_output=None, verbose=False, output_ena_table=None):
     """Autofill the metadata of a table from ENA
 
     Args:
@@ -86,13 +86,14 @@ def run_autofill(accession, table_name=None, schema=None, dataset=None, sample_o
         ])
         query_dict += query_res
     df_out = pd.DataFrame.from_dict(query_dict)
-
+    
     # Output ENA table to .csv.gz file
-    if output_ena_table:
+    if output_ena_table is not None:
+        ena_table_output_path = output_ena_table + '.tsv.gz'
         logger.info(f"ENA Table head (First 5 lines + headers)")
         print(df_out.head(5))
-        logger.info(f"Saving table retrieved from ENA to ena_table.csv.gz")
-        df_out.to_csv('ena_table.tsv.gz', sep='\t', index=False, compression='gzip')
+        df_out.to_csv(ena_table_output_path, sep='\t', index=False, compression='gzip')
+        logger.info(f"Saved ENA table to {ena_table_output_path}")
         
     df_out.rename(
         columns={

--- a/amdirt/autofill/__init__.py
+++ b/amdirt/autofill/__init__.py
@@ -92,7 +92,7 @@ def run_autofill(accession, table_name=None, schema=None, dataset=None, sample_o
         logger.info(f"ENA Table head (First 5 lines + headers)")
         print(df_out.head(5))
         logger.info(f"Saving table retrieved from ENA to ena_table.csv.gz")
-        df_out.to_csv('ena_table.csv.gz', index=False, compression='gzip')
+        df_out.to_csv('ena_table.tsv.gz', sep='\t', index=False, compression='gzip')
         
     df_out.rename(
         columns={

--- a/amdirt/autofill/__init__.py
+++ b/amdirt/autofill/__init__.py
@@ -89,10 +89,10 @@ def run_autofill(accession, table_name=None, schema=None, dataset=None, sample_o
     
     # Output ENA table to .csv.gz file
     if output_ena_table is not None:
-        ena_table_output_path = output_ena_table + '.tsv.gz'
+        ena_table_output_path = output_ena_table + '.tsv'
         logger.info(f"ENA Table head (First 5 lines + headers)")
         print(df_out.head(5))
-        df_out.to_csv(ena_table_output_path, sep='\t', index=False, compression='gzip')
+        df_out.to_csv(ena_table_output_path, sep='\t', index=False)
         logger.info(f"Saved ENA table to {ena_table_output_path}")
         
     df_out.rename(

--- a/amdirt/autofill/__init__.py
+++ b/amdirt/autofill/__init__.py
@@ -89,7 +89,7 @@ def run_autofill(accession, table_name=None, schema=None, dataset=None, sample_o
     
     # Output ENA table to .csv.gz file
     if output_ena_table is not None:
-        ena_table_output_path = output_ena_table + '.tsv'
+        ena_table_output_path = output_ena_table
         logger.info(f"ENA Table head (First 5 lines + headers)")
         print(df_out.head(5))
         df_out.to_csv(ena_table_output_path, sep='\t', index=False)

--- a/amdirt/autofill/__init__.py
+++ b/amdirt/autofill/__init__.py
@@ -7,7 +7,7 @@ import json
 import sys
 import pandas as pd
 
-def run_autofill(accession, table_name=None, schema=None, dataset=None, sample_output=None, library_output=None, verbose=False):
+def run_autofill(accession, table_name=None, schema=None, dataset=None, sample_output=None, library_output=None, verbose=False, output_ena_table=False):
     """Autofill the metadata of a table from ENA
 
     Args:
@@ -56,22 +56,44 @@ def run_autofill(accession, table_name=None, schema=None, dataset=None, sample_o
     query_dict = list()
     for a in accession:
         query_res = ena.query(a, fields=[
+            "experiment_accession",
             "study_accession",
             "run_accession",
-            "secondary_sample_accession",
             "sample_alias",
+            "sample_accession",
+            "secondary_sample_accession",            
+            "nominal_length",
+            "scientific_name",
+            "sample_title",
+            "bam_ftp",
+            "sra_ftp",
             "fastq_ftp",
             "fastq_md5",
             "fastq_bytes",
-            "library_name",
+            "read_count",
+            "submitted_ftp",
+            "submitted_aspera",
+            "submitted_format",
+            "instrument_platform",
             "instrument_model",
+            "scientific_name",
+            "tax_id",
+            "library_name",
             "library_layout",
             "library_strategy",
-            "read_count",
+            "library_selection",
+            "library_source",
         ])
         query_dict += query_res
     df_out = pd.DataFrame.from_dict(query_dict)
 
+    # Output ENA table to .csv.gz file
+    if output_ena_table:
+        logger.info(f"ENA Table head (First 5 lines + headers)")
+        print(df_out.head(5))
+        logger.info(f"Saving table retrieved from ENA to ena_table.csv.gz")
+        df_out.to_csv('ena_table.csv.gz', index=False, compression='gzip')
+        
     df_out.rename(
         columns={
             "study_accession": "archive_project",

--- a/amdirt/cli.py
+++ b/amdirt/cli.py
@@ -234,10 +234,8 @@ def convert(ctx, no_args_is_help=True, **kwargs):
 @click.option(
     "-t",
     "--output_ena_table",
-    is_flag=True, 
-    show_default=True, 
-    default=False,
-    help="Output ENA table to compressed file"
+    type=click.Path(writable=True),
+    help="path to ENA table output file",
 )
 @click.option(
     "-l",

--- a/amdirt/cli.py
+++ b/amdirt/cli.py
@@ -232,6 +232,14 @@ def convert(ctx, no_args_is_help=True, **kwargs):
     show_default=True,
 )
 @click.option(
+    "-t",
+    "--output_ena_table",
+    is_flag=True, 
+    show_default=True, 
+    default=False,
+    help="Output ENA table to compressed file"
+)
+@click.option(
     "-l",
     "--library_output",
     type=click.Path(writable=True),


### PR DESCRIPTION
Refers to #144 

run 'amdirt autofill -t [ACCESSION]' or run 'amdirt autofill --output_ena_table [ACCESSION]' to have your ENA table to .tsv file on local of execution. Also prints first 5 rows to command line for visualization.

CLI output is shown below:

![image](https://github.com/user-attachments/assets/b73640ce-b385-4e39-80fc-3119ac993f24)
