### PR TITLE
Replace algorithm to determine the colour chemistry

### DIFF
--- a/amdirt/core/__init__.py
+++ b/amdirt/core/__init__.py
@@ -103,24 +103,29 @@ def check_allowed_values(ref: list, test: str):
 
 def get_colour_chemistry(instrument: str) -> int:
     """
-    Get number of colours used in sequencing chemistry
+    Get number of colours used in sequencing chemistry. If the instrument is
+    not a known Illumina sequencer with two-dye chemistry, a colour chemistry
+    of four dyes is assumed. 
+
     Args:
         instrument(str): Name of the instrument
     Returns:
         int: number of colours used in sequencing chemistry
     """
-    chemistry_colours = {
-        "bgiseq": 4,
-        "miseq": 4,
-        "hiseq": 4,
-        "genome analyzer": 4,
-        "nextseq": 2,
-        "novaseq": 2,
-    }
-
-    for k in chemistry_colours:
-        if k in instrument.lower():
-            return chemistry_colours[k]
+    instruments_2dye = [
+        "Illumina MiniSeq",
+        "Illumina NovaSeq 6000",
+        "Illumina NovaSeq X",
+        "Illumina iSeq 100",
+        "NextSeq 1000",
+        "NextSeq 2000",
+        "NextSeq 500",
+        "NextSeq 550",
+    ]
+    if instrument in instruments_2dye:
+        return 2
+    else:
+        return 4
 
 
 def doi2bib(doi: str) -> str:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,8 +7,8 @@ from amdirt.core import (
 
 def test_get_colour_chemistry():
 
-    assert get_colour_chemistry("hiseq") == 4
-    assert get_colour_chemistry("novaseq") == 2
+    assert get_colour_chemistry("Illumina HiSeq 2500") == 4
+    assert get_colour_chemistry("Illumina NovaSeq 6000") == 2
 
 
 def test_doi2bib():


### PR DESCRIPTION
It was simplified to when the instrument is not a known Illumina sequencer with two-dye chemistry, a colour chemistry of four dyes is assumed.

This addresses the issue #150 because it returns 4 as a value for any non-Illumina sequencer or Illumina sequencers with a 4-dye chemistry.