### PR TITLE
Add localpat to json schema amdirt validate

### DIFF
--- a/amdirt/cli.py
+++ b/amdirt/cli.py
@@ -92,6 +92,12 @@ def cli(ctx, verbose, no_args_is_help=True, **kwargs):
     default=None,
     help="[Optional] Path/URL to remote reference sample table for archive accession validation",
 )
+@click.option(
+    "-l",
+    "--local_json_schema",
+    type=click.Path(writable=True),
+    help="path to folder with local JSON schemas",
+)
 @click.option("-m", "--markdown", is_flag=True, help="Output is in markdown format")
 @click.pass_context
 def validate(ctx, no_args_is_help=True, **kwargs):

--- a/amdirt/configuration/configuration.py
+++ b/amdirt/configuration/configuration.py
@@ -1,0 +1,12 @@
+class Settings:
+    def __init__(self):
+        self.local_json_schema = None
+
+    def update(self, updates):
+        for key, value in updates.items():
+            if hasattr(self, key): 
+                setattr(self, key, value)
+            else:
+                print(f"Warning: Setting '{key}' not found.") 
+
+settings = Settings() 

--- a/amdirt/validate/__init__.py
+++ b/amdirt/validate/__init__.py
@@ -1,10 +1,13 @@
 from amdirt.validate.application import AMDirValidator
 import warnings
 
+import amdirt.configuration.configuration as config
+
 def run_validation(
     dataset,
     schema,
     schema_check,
+    local_json_schema,
     line_dup,
     columns,
     doi,
@@ -14,6 +17,9 @@ def run_validation(
     markdown,
     verbose,
 ):
+    if local_json_schema:
+        config.settings.update({"local_json_schema": local_json_schema})
+        
     if not verbose:
         warnings.filterwarnings("ignore")
     v = AMDirValidator(schema, dataset)

--- a/amdirt/validate/domain/__init__.py
+++ b/amdirt/validate/domain/__init__.py
@@ -126,7 +126,7 @@ class DatasetValidator:
             
             if config.settings.local_json_schema:
                 remote_ref_path = "https://spaam-community.github.io/AncientMetagenomeDir/assets/enums/"
-                local_ref_path = os.path.abspath(config.settings.local_json_schema) + "/"
+                local_ref_path = "file://" + os.path.abspath(config.settings.local_json_schema) + "/"
                 
                 for key in json_schema["items"]["properties"]:
                     if "$ref" in json_schema["items"]["properties"][key]:

--- a/amdirt/validate/domain/__init__.py
+++ b/amdirt/validate/domain/__init__.py
@@ -1,5 +1,6 @@
 import json
 import pandas as pd
+import amdirt.configuration.configuration as config
 from amdirt.validate import exceptions
 from amdirt.core import logger
 from io import StringIO
@@ -11,6 +12,7 @@ from jsonschema import Draft7Validator, exceptions as json_exceptions
 from typing import AnyStr, BinaryIO, TextIO, Union
 import requests
 import re
+import os
 
 Schema = Union[AnyStr, BinaryIO, TextIO]
 Dataset = Union[AnyStr, BinaryIO, TextIO]
@@ -113,13 +115,26 @@ class DatasetValidator:
         try:
             if str(schema).startswith("http"):
                 res = requests.get(schema)
+                json_schema = {}
                 if res.status_code == 200:
-                    return res.json()
+                    json_schema = res.json()
                 else:
                     raise Exception("Could not fetch schema from URL")
             else:
                 with open(schema, "r") as s:
-                    return json.load(s)
+                    json_schema = json.load(s)
+            
+            if config.settings.local_json_schema:
+                remote_ref_path = "https://spaam-community.github.io/AncientMetagenomeDir/assets/enums/"
+                local_ref_path = os.path.abspath(config.settings.local_json_schema) + "/"
+                
+                for key in json_schema["items"]["properties"]:
+                    if "$ref" in json_schema["items"]["properties"][key]:
+                        val = json_schema["items"]["properties"][key]["$ref"] 
+                        val = val.replace(remote_ref_path, local_ref_path)
+                        json_schema["items"]["properties"][key]["$ref"] = val
+                        
+            return json_schema
         except json.JSONDecodeError as e:
             msg = str(e.with_traceback(e.__traceback__))
             self.add_error(

--- a/amdirt/viewer/__init__.py
+++ b/amdirt/viewer/__init__.py
@@ -1,5 +1,5 @@
 # from amdirt import logger
-from distutils.log import warn
+# from distutils.log import warn
 import sys
 from streamlit.web import cli as stcli
 from pathlib import Path

--- a/amdirt/viewer/__init__.py
+++ b/amdirt/viewer/__init__.py
@@ -1,5 +1,4 @@
 # from amdirt import logger
-# from distutils.log import warn
 import sys
 from streamlit.web import cli as stcli
 from pathlib import Path


### PR DESCRIPTION
Refers to issue #160 

Added flag -l to amdirt validate. Need to pass the path to where the jsons are located (e.g., <$LOCAL_PATH>/assets/enum).

Added configuration module to deal with flag settings across modules without getting too messy.