### PR TITLE
Remove link annotation from the error message string

### DIFF
--- a/amdirt/validate/domain/__init__.py
+++ b/amdirt/validate/domain/__init__.py
@@ -250,7 +250,7 @@ class DatasetValidator:
         err_column = list(error.path)[-1]
         if "enum" in error.schema:
             if len(error.schema["enum"]) > 3:
-                error.message = f"'{error.instance}' is not an accepted value.\nPlease check [link={self.schema['items']['properties'][err_column]['$ref']}]{self.schema['items']['properties'][err_column]['$ref']}[/link]"
+                error.message = f"'{error.instance}' is not an accepted value.\nPlease check {self.schema['items']['properties'][err_column]['$ref']}"
         err_line = str(error.path[0])
         return DFError(
             "Schema Validation Error",


### PR DESCRIPTION
This removes the annotation `[link]` and `[/link]` from the code that is supposed to clean the JSON schema error messages. However, while these annotations might improve the readability of the URL to the JSON schema, they are wrongly displayed on GitHub when running amdirt validate as part of the GitHub workflow.

This addresses issue #165.