### PR TITLE
Except TypeError to trigger JSON schema error message

### DIFF
--- a/amdirt/validate/domain/__init__.py
+++ b/amdirt/validate/domain/__init__.py
@@ -182,7 +182,7 @@ class DatasetValidator:
                 column_dtypes[column_keys] = coltype
         try:
             return pd.read_table(dataset, sep="\t", dtype=column_dtypes)
-        except (AttributeError, pd.errors.ParserError, ValueError) as e:
+        except (AttributeError, pd.errors.ParserError, ValueError, TypeError) as e:
             self.add_error(
                 DFError(
                     "Dataset Parsing Error",


### PR DESCRIPTION
Using the JSON schema, amdirt enforces reading the columns of the AMDir tables in the expected column types. If the type differs, e.g. instead of integer it is float, an error of the type TypeError is thrown. See issue #121.

This PR adds an exception for a TypeError and therefore triggers the display of the reason for the error.

<img width="1126" alt="amdirt_TypeError_example" src="https://github.com/user-attachments/assets/3e7dd9d0-fdc3-4a2d-beb1-b550ac3622c3" />
