### PR TITLE
Infer required BibTex entries from the library table instead of the sample table

### DIFF
--- a/amdirt/convert/__init__.py
+++ b/amdirt/convert/__init__.py
@@ -131,7 +131,7 @@ def run_convert(
         bibfile = f"{output}/AncientMetagenomeDir_bibliography.bib"
         logger.info(f"Writing Bibtex citation file to {bibfile}")
         with open(bibfile, "w") as fw:
-            fw.write(prepare_bibtex_file(samples))
+            fw.write(prepare_bibtex_file(libraries))
 
     if table_name in ["ancientmetagenome-environmental"]:
         col_drop = ["archive_accession"]

--- a/amdirt/core/__init__.py
+++ b/amdirt/core/__init__.py
@@ -519,10 +519,10 @@ def prepare_aMeta_table(
 
 
 @st.cache_data
-def prepare_bibtex_file(samples: pd.DataFrame) -> str:
+def prepare_bibtex_file(libraries: pd.DataFrame) -> str:
     dois = set()
     failed_dois = set()
-    dois_set = set(list(samples["publication_doi"]))
+    dois_set = set(list(libraries["data_publication_doi"]))
     dois_set.add("10.1038/s41597-021-00816-y")
     for doi in dois_set:
         try:

--- a/docs/source/how_to/convert.md
+++ b/docs/source/how_to/convert.md
@@ -59,7 +59,7 @@ All possible output is as follows:
 
 - `<outdir>`: where all the pipeline samplesheets are placed (by default `.`)
 - `AncientMetagenomeDir_bibliography.bib`:
-  - A BibTex format citation information file with all references (where available) present in the filtered sample table.
+  - A BibTex format citation information file with all references (where available) present in the filtered sample table. In case a library table is provided using `--libraries`, only the references relevant to the selected libraries are reported.
 - `AncientMetagenomeDir_filtered_libraries.tsv`:
   - The associated AncientMetagenomeDir curated metadata for all _libraries_ of the samples in the input table.
 - `AncientMetagenomeDir_curl_download_script.sh`:


### PR DESCRIPTION
This should solve the issue #147.

Instead of using the list of samples as the input for the function that retrieves the DOI values, it uses the library table instead. In the example that @jfy133 posted in the issue #147, this version now drops Warinner2024 because their samples are only single-end sequenced but instead adds Klapper2023 as the study published additional paired-end sequencing data for samples from the study FellowsYates2021.